### PR TITLE
wrap-borders_apply-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,18 @@ function of the preceding one). The rules continue to be applied repeatedly to c
 2. Take help to learn the command line arguments being accepted by the program
     ```shell 
     game-of-life % go run . -help                            
-    Usage of /var/folders/xt/l7kq1dlx3fj8s3p15prcpy9w0000gn/T/go-build2668948479/b001/exe/game-of-life:
+    Usage of /var/folders/xt/l7kq1dlx3fj8s3p15prcpy9w0000gn/T/go-build2568731570/b001/exe/game-of-life:
     This is a custom usage message.
-      -cols int
-            Number of columns in the universe (default 5)
-      -rows int
-            Number of rows in the universe (default 5)
-      -seed string
-            Seed pattern for the universe (default, glider) (default "default")
+        -cols int
+                Number of columns in the universe (default 5)
+        -rows int
+                Number of rows in the universe (default 5)
+        -rules string
+                Comma-separated rule names (e.g., conway,no-top-left). Available: [conway no-top-left] (default "conway")
+        -runs int
+                Number of runs to execute (default 25)
+        -seed string
+                Seed pattern for the universe (default, glider) (default "default")
     ```
 
  3. execute with appropriate command line values
@@ -173,6 +177,10 @@ Performance benchmarks below proves, with optimized data structure and algorithm
     ```
 
 </details>
+
+### Recent modifications those were not in the actual requirements
+1. Accept which rules to apply dynamically from command line arguments.
+2. Wrap around the pattern when it tried to go beyond the universe grid border - bottum-right should start appearing from the top-left so on and so forth.
 
 ### Next steps
 1. Performance improvment: Is it possible to use in-place updates to avoid runtime memory allocation? 

--- a/gameoflife/game_of_life.go
+++ b/gameoflife/game_of_life.go
@@ -13,17 +13,24 @@ const (
 	whiteChar       = "\033[47m \033[0m"
 )
 
+// Cell represents a cell in the Game of Life universe with its row and column indices.
+// It is used as a key in the universe map to track live cells.
+type Cell struct {
+	R, C int
+}
+
 type GameOfLife struct {
-	universe          map[[2]int]struct{} // todo: [2]int can also be defined as `type Cell struct { Row int, Col int }`
+	universe          map[Cell]struct{}
 	numRows           int
 	numCols           int
-	neighbouringCells [][]int
+	neighbouringCells []Cell
+	rules             []Rule
 }
 
 // CreateSeedUniverse create seed universe based on the given row, col and seed pattern
 // It initializes the universe with the specified seed pattern and returns a pointer to GameOfLife.
 // If the row or col is less than or equal to zero, it returns nil.
-func CreateSeedUniverse(row, col int, seedPattern SEED_PATTERN) *GameOfLife {
+func CreateSeedUniverse(row, col int, seedPattern SEED_PATTERN, rules ...Rule) *GameOfLife {
 	// should omit `input == nil` check; len() for nil slices is defined as zero
 	if row <= 0 || col <= 0 {
 		return nil
@@ -34,23 +41,24 @@ func CreateSeedUniverse(row, col int, seedPattern SEED_PATTERN) *GameOfLife {
 		universe: GetSeedGrid(seedPattern, row, col),
 		numRows:  row,
 		numCols:  col,
-		neighbouringCells: [][]int{
-			{-1, -1}, {-1, 0}, {-1, 1},
-			{0, -1}, {0, 1},
-			{1, -1}, {1, 0}, {1, 1},
+		neighbouringCells: []Cell{
+			{R: -1, C: -1}, {R: -1, C: 0}, {R: -1, C: 1},
+			{R: 0, C: -1}, {R: 0, C: 1},
+			{R: 1, C: -1}, {R: 1, C: 0}, {R: 1, C: 1},
 		},
+		rules: rules,
 	}
 }
 
 // Display displays the current state of the Game of Life universe to the standard output.
 // Alive cells are represented by whiteChar, and dead cells by blackChar.
 // The universe is printed row by row, with each cell separated by a space.
-func (u GameOfLife) Display() {
+func (g GameOfLife) Display() {
 	fmt.Println("==============")
 
-	for rowIndex := range u.numRows {
-		for colIndex := range u.numCols {
-			if _, ok := u.universe[[2]int{rowIndex, colIndex}]; ok {
+	for rowIndex := range g.numRows {
+		for colIndex := range g.numCols {
+			if _, ok := g.universe[Cell{rowIndex, colIndex}]; ok {
 				fmt.Print(" ", whiteChar)
 			} else {
 				fmt.Print(" ", blackChar)
@@ -68,23 +76,23 @@ func (u GameOfLife) Display() {
 //
 //	generations - the number of generations to simulate.
 //	delay - the duration to wait between each generation.
-func (u *GameOfLife) Run(generations int, delay time.Duration) {
+func (g *GameOfLife) Run(generations int, delay time.Duration) {
 	fmt.Printf("Original Generation:\n")
-	u.Display()
+	g.Display()
 	for i := 1; i <= generations; i++ {
 		fmt.Print("\033[H\033[2J") // Clear screen before printing next frame
 		fmt.Printf("Generation: %d\n", i)
-		u.CreateNextGeneration()
-		u.Display()
+		g.CreateNextGeneration()
+		g.Display()
 		time.Sleep(delay)
 	}
 }
 
-// _isValidNeighbour return true if the given cell coordinates (neighbourCellRow, neighbourCellCol)
+// _wrapCellWithinUniverse return border bound cooridinates for row and col if the given cell coordinates (neighbourCellRow, neighbourCellCol) beyond the boundry
 // are within the valid bounds of the Game of Life grid, otherwise false.
-func (u *GameOfLife) _isValidNeighbour(neighbourCellRow int, neighbourCellCol int) bool {
-	return neighbourCellRow >= 0 && neighbourCellRow < u.numRows &&
-		neighbourCellCol >= 0 && neighbourCellCol < u.numCols
+func (g *GameOfLife) _wrapCellWithinUniverse(cell Cell) Cell {
+	// Wrap coordinates using modulo for toroidal (wrap-around) universe
+	return Cell{(cell.R + g.numRows) % g.numRows, (cell.C + g.numCols) % g.numCols}
 }
 
 // _markNeighbourAlive increments the count of alive neighbours for each valid neighbouring cell
@@ -95,15 +103,14 @@ func (u *GameOfLife) _isValidNeighbour(neighbourCellRow int, neighbourCellCol in
 // Parameters:
 //   - currentPosition: a [2]int array representing the row and column of the current cell.
 //   - neighborCounts: a pointer to a map that tracks the count of alive neighbours for each cell.
-func (u *GameOfLife) _markNeighbourAlive(currentPosition [2]int, neighborCounts *map[[2]int]int) {
+func (g *GameOfLife) _markNeighbourAlive(currentPosition Cell, neighborCounts *map[Cell]int) {
 
-	for _, neighbourCell := range u.neighbouringCells {
-		neighbourCellRow := currentPosition[0] + neighbourCell[0]
-		neighbourCellCol := currentPosition[1] + neighbourCell[1]
-
-		if u._isValidNeighbour(neighbourCellRow, neighbourCellCol) {
-			(*neighborCounts)[[2]int{neighbourCellRow, neighbourCellCol}]++
-		}
+	for _, neighbourCell := range g.neighbouringCells {
+		neighbourCell = g.
+			_wrapCellWithinUniverse(
+				Cell{(currentPosition.R + neighbourCell.R), (currentPosition.C + neighbourCell.C)},
+			)
+		(*neighborCounts)[neighbourCell]++
 	}
 }
 
@@ -115,29 +122,48 @@ func (u *GameOfLife) _markNeighbourAlive(currentPosition [2]int, neighborCounts 
 //  3. Any live cell with more than three live neighbours dies (overcrowding).
 //  4. Any dead cell with exactly three live neighbours becomes a live cell (reproduction).
 //
+// updated:
+// #3 will be: more than 4 neight would be overcrowding
+// #5 cell has live neighbour on top left, it will always die
+//
 // The new universe is created which replaces existing one.
-func (u *GameOfLife) CreateNextGeneration() {
-	neighborCounts := make(map[[2]int]int)
-	newUniverse := make(map[[2]int]struct{})
+func (g *GameOfLife) CreateNextGeneration() {
+	neighborCounts := make(map[Cell]int)
+	newUniverse := make(map[Cell]struct{})
 
 	// for every live cell, count the number of live neighbours
-	for key := range u.universe {
-		u._markNeighbourAlive(key, &neighborCounts)
+	for cell := range g.universe {
+		g._markNeighbourAlive(cell, &neighborCounts)
 	}
 
-	for key, value := range neighborCounts {
-		_, isCellAlive := u.universe[[2]int{key[0], key[1]}]
-		if value == 3 && !isCellAlive {
-			newUniverse[[2]int{key[0], key[1]}] = struct{}{}
+	// Union all the cells that have live neighbours
+	// This is done to ensure that we consider all cells that could potentially become alive
+	candidates := make(map[Cell]struct{})
+	for cell := range neighborCounts {
+		candidates[cell] = struct{}{}
+	}
+	// Also include all currently alive cells
+	for cell := range g.universe {
+		candidates[cell] = struct{}{}
+	}
+
+	// Iterate through all candidate cells to apply the rules
+	// and determine their next state based on the number of live neighbours.
+	// This is where the rules are applied to determine if a cell should be alive or dead
+	// based on the neighborCounts.
+	for cell := range candidates {
+		// Check if the cell is currently alive
+		_, isCellAlive := g.universe[cell]
+		neighborCount := neighborCounts[cell]
+
+		// Apply each rule to determine if the cell should be alive in the next generation
+		for _, rule := range g.rules {
+			if rule.Apply(cell, isCellAlive, neighborCount, g) {
+				newUniverse[cell] = struct{}{}
+				break // If any rule applies, we can stop checking further rules for this cell
+			}
 		}
 	}
 
-	for key := range u.universe {
-		neighborCount := neighborCounts[[2]int{key[0], key[1]}]
-		if neighborCount == 2 || neighborCount == 3 {
-			newUniverse[[2]int{key[0], key[1]}] = struct{}{}
-		}
-	}
-
-	u.universe = newUniverse
+	g.universe = newUniverse
 }

--- a/gameoflife/rule.go
+++ b/gameoflife/rule.go
@@ -1,0 +1,30 @@
+package gameoflife
+
+// Rule interface defines the structure for rules that can be applied to cells in the Game of Life.
+// The Apply method takes a cell, its alive status, the count of its live neighbors,
+// and a pointer to the GameOfLife instance. It returns a boolean indicating whether the cell
+// should be alive in the next generation based on the rules defined by the implementing type.
+// This allows for flexible rule definitions, enabling different behaviors in the Game of Life simulation.
+type Rule interface {
+	// Apply returns true if the cell should be alive in the next generation.
+	Apply(cell Cell, alive bool, neighborCount int, g *GameOfLife) bool
+}
+
+type ConwayRule struct{}
+
+func (r ConwayRule) Apply(cell Cell, alive bool, neighborCount int, g *GameOfLife) bool {
+	if alive {
+		// Underpopulation or Overcrowding
+		return neighborCount == 2 || neighborCount == 3
+	}
+	// Reproduction
+	return neighborCount == 3
+}
+
+type NoTopLeftNeighborRule struct{}
+
+func (r NoTopLeftNeighborRule) Apply(cell Cell, alive bool, neighborCount int, g *GameOfLife) bool {
+	topLeftCell := g._wrapCellWithinUniverse(Cell{cell.R - 1, cell.C - 1})
+	_, hasTopLeft := g.universe[topLeftCell]
+	return !hasTopLeft && alive
+}

--- a/gameoflife/rule_factory.go
+++ b/gameoflife/rule_factory.go
@@ -1,0 +1,57 @@
+package gameoflife
+
+import "strings"
+
+// RuleType is an enumeration for different rule types.
+type RuleType int
+
+const (
+	// ConwayRuleType represents the Conway's Game of Life rule.
+	ConwayRuleType RuleType = iota
+	// NoTopLeftNeighborRuleType represents a rule that checks for the absence of a top left neighbor.
+	NoTopLeftNeighborRuleType
+)
+
+var ruleNameToType = map[string]RuleType{
+	"conway":      ConwayRuleType,
+	"no-top-left": NoTopLeftNeighborRuleType,
+}
+
+func RuleFactory(ruleType RuleType) Rule {
+	switch ruleType {
+	case ConwayRuleType:
+		return ConwayRule{}
+	case NoTopLeftNeighborRuleType:
+		return NoTopLeftNeighborRule{}
+	default:
+		// Return a default rule if no valid type is provided
+		return ConwayRule{}
+	}
+}
+
+// ParseRulesFromString parses comma-separated rule names into []Rule.
+func ParseRulesFromString(rulesString string) []Rule {
+	rules := make([]Rule, 0)
+
+	if len(rulesString) == 0 {
+		return rules
+	}
+
+	for _, ruleString := range strings.Split(rulesString, ",") {
+		ruleString = strings.ToLower(strings.TrimSpace(ruleString))
+		if ruleName, ok := ruleNameToType[ruleString]; ok {
+			rules = append(rules, RuleFactory(ruleName))
+		}
+	}
+
+	return rules
+}
+
+// AvailableRuleNames returns all valid rule names for CLI/help.
+func AvailableRuleNames() []string {
+	keys := make([]string, 0, len(ruleNameToType))
+	for k := range ruleNameToType {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/gameoflife/seed.go
+++ b/gameoflife/seed.go
@@ -18,11 +18,11 @@ func (s SEED_PATTERN) String() string {
 
 // GetSeedGrid returns a map representing the initial seed grid for Conway's Game of Life,
 // based on the specified seed pattern and grid dimensions (row, col).
-// The map keys are [2]int arrays representing cell coordinates, and the values are booleans
+// The map keys are Cell arrays representing cell coordinates, and the values are booleans
 // indicating whether the cell is alive (true) or dead (false).
 // Supported seed patterns are defined by the SEED_PATTERN type.
 // If an unsupported pattern is provided, a default seed pattern is returned.
-func GetSeedGrid(seedPattern SEED_PATTERN, row, col int) map[[2]int]struct{} {
+func GetSeedGrid(seedPattern SEED_PATTERN, row, col int) map[Cell]struct{} {
 	switch seedPattern {
 	case Glider:
 		return getSeedGliderPattern(row, col)
@@ -33,7 +33,7 @@ func GetSeedGrid(seedPattern SEED_PATTERN, row, col int) map[[2]int]struct{} {
 
 // getSeedGliderPattern returns a map representing the initial seed positions of a glider pattern
 // for Conway's Game of Life, centered within a grid of the specified number of rows and columns.
-// The map keys are [2]int arrays representing the (row, column) coordinates of live cells.
+// The map keys are Cell arrays representing the (row, column) coordinates of live cells.
 // The glider pattern is a well-known configuration that moves diagonally across the grid over time.
 //
 // Parameters:
@@ -43,19 +43,19 @@ func GetSeedGrid(seedPattern SEED_PATTERN, row, col int) map[[2]int]struct{} {
 //
 // Returns:
 //
-//	A map with keys as [2]int coordinates and values as bool (true for live cells), representing
+//	A map with keys as Cell coordinates and values as bool (true for live cells), representing
 //	the initial positions of the glider pattern centered in the grid.
-func getSeedGliderPattern(rows, cols int) map[[2]int]struct{} {
-	seedGrid := make(map[[2]int]struct{})
+func getSeedGliderPattern(rows, cols int) map[Cell]struct{} {
+	seedGrid := make(map[Cell]struct{})
 
 	// Offset to center the glider
 	r, c := rows/2, cols/2
 
-	seedGrid[[2]int{r, c + 1}] = struct{}{}
-	seedGrid[[2]int{r + 1, c + 2}] = struct{}{}
-	seedGrid[[2]int{r + 2, c}] = struct{}{}
-	seedGrid[[2]int{r + 2, c + 1}] = struct{}{}
-	seedGrid[[2]int{r + 2, c + 2}] = struct{}{}
+	seedGrid[Cell{r, c + 1}] = struct{}{}
+	seedGrid[Cell{r + 1, c + 2}] = struct{}{}
+	seedGrid[Cell{r + 2, c}] = struct{}{}
+	seedGrid[Cell{r + 2, c + 1}] = struct{}{}
+	seedGrid[Cell{r + 2, c + 2}] = struct{}{}
 
 	return seedGrid
 }
@@ -72,17 +72,17 @@ func getSeedGliderPattern(rows, cols int) map[[2]int]struct{} {
 //
 // Returns:
 //
-//	A map with keys as [2]int coordinates and values as booleans indicating
+//	A map with keys as Cell coordinates and values as booleans indicating
 //	live cells in the initial seed pattern.
-func getDefaultSeedPattern(rows, cols int) map[[2]int]struct{} {
-	seedGrid := make(map[[2]int]struct{})
+func getDefaultSeedPattern(rows, cols int) map[Cell]struct{} {
+	seedGrid := make(map[Cell]struct{})
 
 	// Offset to center the glider
 	r, c := rows/2, cols/2
 
-	seedGrid[[2]int{r - 1, c}] = struct{}{}
-	seedGrid[[2]int{r, c}] = struct{}{}
-	seedGrid[[2]int{r + 1, c}] = struct{}{}
+	seedGrid[Cell{r - 1, c}] = struct{}{}
+	seedGrid[Cell{r, c}] = struct{}{}
+	seedGrid[Cell{r + 1, c}] = struct{}{}
 
 	return seedGrid
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ func main() {
 	seedPatternStr := flag.String("seed", gameoflife.Default.String(), "Seed pattern for the universe (default, glider)")
 	rows := flag.Int("rows", 5, "Number of rows in the universe")
 	cols := flag.Int("cols", 5, "Number of columns in the universe")
+	ruleNames := flag.String("rules", "conway", fmt.Sprintf("Comma-separated rule names (e.g., conway,no-top-left). Available: %v", gameoflife.AvailableRuleNames()))
+	numberOfRuns := flag.Int("runs", 25, "Number of runs to execute")
 
 	// Parse the command line flags
 	flag.Parse()
@@ -39,6 +41,7 @@ func main() {
 	}
 
 	// Create the Game of Life universe with the specified seed pattern and dimensions
-	game := gameoflife.CreateSeedUniverse(*rows, *cols, seedPattern)
-	game.Run(25, 500*time.Millisecond)
+	rules := gameoflife.ParseRulesFromString(*ruleNames)
+	game := gameoflife.CreateSeedUniverse(*rows, *cols, seedPattern, rules...)
+	game.Run(*numberOfRuns, 500*time.Millisecond)
 }


### PR DESCRIPTION
1. changes to wrap around the pattern movement from one border side to other side of the universe grid.
2. make provision for user to pass rules at runtime as an command line argument.